### PR TITLE
Add flaky test runner and web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-## Test Analyzer
+# Test Analyzer
+
+Detect flaky tests across any framework by running your test command multiple times and analyzing the results.
+
+## Usage
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Run the analyzer**
+   ```bash
+   npx tsc
+   node dist/main.js --command "npm test" --repeat 10
+   ```
+   - `--command` – shell command to execute for each run
+   - `--repeat`  – number of times to run the command (default: `10`)
+
+   The command output is parsed for lines matching `✓ Test Name` or `✕ Test Name` and a `results.json` file is produced.
+
+3. **View the report**
+   - Navigate to the `ui` folder and install its dependencies: `npm install`
+   - Run the development server: `npm run dev`
+   - Open the provided URL to see the dashboard
+
+## Flake Score
+
+`flakeScore` is the percentage of runs where a test failed. A test is considered **flaky** if it fails at least once.
+
+Example summary output:
+```
+🧪 Flaky Tests (3):
+ - "Login fails with 500" — 4/10 failed (flakeScore: 40%)
+ - "Search results persist" — 2/10 failed (flakeScore: 20%)
+```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/folterung/atdd-analyzer#readme",
   "devDependencies": {
     "@types/jest": "24.0.18",
+    "@types/minimist": "^1.2.5",
     "@types/node": "12.7.2",
     "jest": "24.9.0",
     "ts-jest": "24.0.2",
@@ -26,10 +27,13 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
+    "minimist": "^1.2.8",
     "rxjs": "6.5.2"
   },
   "jest": {
-    "roots": [ "./src" ], 
+    "roots": [
+      "./src"
+    ],
     "preset": "ts-jest",
     "testEnvironment": "node"
   }

--- a/src/lib/runner/index.ts
+++ b/src/lib/runner/index.ts
@@ -1,1 +1,2 @@
 export { Runner } from './runner';
+export * from './runner'; // export types as well

--- a/src/lib/runner/runner.ts
+++ b/src/lib/runner/runner.ts
@@ -1,3 +1,74 @@
-export class Runner {
+import { exec } from 'child_process';
+import { promisify } from 'util';
 
+export type TestStatus = 'pass' | 'fail';
+
+export interface TestRecord {
+  name: string;
+  statusHistory: TestStatus[];
+  passCount: number;
+  failCount: number;
+  flakeScore: number;
+  isFlaky: boolean;
 }
+
+export interface RunnerResult {
+  command: string;
+  repeat: number;
+  tests: TestRecord[];
+}
+
+const execAsync = promisify(exec);
+
+export class Runner {
+  constructor(private command: string, private repeat: number = 10) {}
+
+  async run(): Promise<RunnerResult> {
+    const map: Map<string, TestRecord> = new Map();
+
+    for (let i = 0; i < this.repeat; i++) {
+      const { stdout, stderr } = await execAsync(this.command, { maxBuffer: 1024 * 1024 * 10 });
+      const output = stdout.toString() + '\n' + stderr.toString();
+      const lines = output.split(/\r?\n/);
+      for (const line of lines) {
+        const passMatch = line.match(/^\s*[✓✔√]\s+(.*)/);
+        const failMatch = line.match(/^\s*[✕✖×X]\s+(.*)/);
+        if (passMatch || failMatch) {
+          const status: TestStatus = passMatch ? 'pass' : 'fail';
+          const name = (passMatch ? passMatch[1] : failMatch![1]).trim();
+          let record = map.get(name);
+          if (!record) {
+            record = {
+              name,
+              statusHistory: [],
+              passCount: 0,
+              failCount: 0,
+              flakeScore: 0,
+              isFlaky: false,
+            };
+            map.set(name, record);
+          }
+          record.statusHistory.push(status);
+          if (status === 'pass') {
+            record.passCount += 1;
+          } else {
+            record.failCount += 1;
+          }
+        }
+      }
+    }
+
+    // finalize records
+    for (const record of Array.from(map.values())) {
+      record.flakeScore = record.failCount / this.repeat * 100;
+      record.isFlaky = record.failCount > 0;
+    }
+
+    return {
+      command: this.command,
+      repeat: this.repeat,
+      tests: Array.from(map.values()),
+    };
+  }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,36 @@
-import { exec$ } from './lib/rx-helpers/exec$';
+import fs from 'fs';
+import minimist from 'minimist';
+import { Runner } from './lib/runner';
 
-import { ExecException } from 'child_process';
-import { Observer } from 'rxjs';
+async function main() {
+  const args = minimist(process.argv.slice(2), {
+    string: ['command'],
+    default: { repeat: 10 },
+  });
 
-const observer: Observer<string> = {
-  next: (stdout: string) => {
-    console.log('Output: ', stdout);
-  },
-  error: (err: ExecException) => {
-    console.log(`Command: ${err.cmd}`);
-    console.log(`Error code: ${err.code}`);
-  },
-  complete: () => {
-    console.log('Observable has completed!');
+  const command = args.command as string;
+  const repeat = parseInt(args.repeat as string, 10) || 10;
+
+  if (!command) {
+    console.error('Error: --command is required');
+    process.exit(1);
   }
-};
 
-exec$('rm Spaghetti').subscribe(observer);
+  const runner = new Runner(command, repeat);
+  const results = await runner.run();
+
+  fs.writeFileSync('results.json', JSON.stringify(results, null, 2));
+
+  // simple summary output
+  const flaky = results.tests.filter(t => t.isFlaky);
+  if (flaky.length > 0) {
+    console.log(`\uD83E\uDD6A Flaky Tests (${flaky.length}):`);
+    for (const t of flaky) {
+      console.log(` - "${t.name}" \u2014 ${t.failCount}/${repeat} failed (flakeScore: ${t.flakeScore.toFixed(0)}%)`);
+    }
+  } else {
+    console.log('All tests passed consistently.');
+  }
+}
+
+main();

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Analyzer</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="p-4">
+    <div id="root"></div>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-analyzer-ui",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.1",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.17",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/ui/postcss.config.js
+++ b/ui/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,14 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import TestDetail from './pages/TestDetail';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/test/:name" element={<TestDetail />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/ui/src/env.d.ts
+++ b/ui/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+interface TestRecord {
+  name: string;
+  statusHistory: ('pass' | 'fail')[];
+  passCount: number;
+  failCount: number;
+  flakeScore: number;
+  isFlaky: boolean;
+}
+
+interface Results {
+  command: string;
+  repeat: number;
+  tests: TestRecord[];
+}
+
+export default function Dashboard() {
+  const [results, setResults] = useState<Results | null>(null);
+  const [showOnlyFlaky, setShowOnlyFlaky] = useState(false);
+  const [sortBy, setSortBy] = useState<'name' | 'flake'>('flake');
+
+  useEffect(() => {
+    fetch('/results.json')
+      .then((r) => r.json())
+      .then(setResults)
+      .catch(() => {});
+  }, []);
+
+  const tests = results?.tests || [];
+  const filtered = tests.filter((t) => (showOnlyFlaky ? t.isFlaky : true));
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === 'flake') return b.flakeScore - a.flakeScore;
+    return a.name.localeCompare(b.name);
+  });
+
+  return (
+    <div className="container mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Flake Dashboard</h1>
+      <div className="mb-2 space-x-4">
+        <label>
+          <input type="checkbox" checked={showOnlyFlaky} onChange={(e) => setShowOnlyFlaky(e.target.checked)} /> Show only flaky
+        </label>
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value as any)} className="border p-1">
+          <option value="flake">Sort by flake score</option>
+          <option value="name">Sort by name</option>
+        </select>
+      </div>
+      <table className="table-auto w-full text-left border">
+        <thead>
+          <tr>
+            <th className="border px-2">Test Name</th>
+            <th className="border px-2">Flake %</th>
+            <th className="border px-2">Fails</th>
+            <th className="border px-2">History</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((t) => (
+            <tr key={t.name} className="border-b hover:bg-gray-50">
+              <td className="px-2 py-1 text-blue-600 underline">
+                <Link to={`/test/${encodeURIComponent(t.name)}`}>{t.name}</Link>
+              </td>
+              <td className="px-2 py-1">{t.flakeScore.toFixed(0)}%</td>
+              <td className="px-2 py-1">{t.failCount}</td>
+              <td className="px-2 py-1">
+                {t.statusHistory.map((s, idx) => (
+                  <span key={idx}>{s === 'pass' ? '✅' : '❌'}</span>
+                ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/pages/TestDetail.tsx
+++ b/ui/src/pages/TestDetail.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Chart, BarController, BarElement, CategoryScale, LinearScale } from 'chart.js';
+
+Chart.register(BarController, BarElement, CategoryScale, LinearScale);
+
+interface TestRecord {
+  name: string;
+  statusHistory: ('pass' | 'fail')[];
+  passCount: number;
+  failCount: number;
+  flakeScore: number;
+  isFlaky: boolean;
+}
+
+interface Results {
+  command: string;
+  repeat: number;
+  tests: TestRecord[];
+}
+
+export default function TestDetail() {
+  const { name } = useParams();
+  const [record, setRecord] = useState<TestRecord | null>(null);
+
+  useEffect(() => {
+    fetch('/results.json')
+      .then((r) => r.json())
+      .then((res: Results) => {
+        const found = res.tests.find((t) => t.name === name);
+        setRecord(found || null);
+      });
+  }, [name]);
+
+  useEffect(() => {
+    if (!record) return;
+    const canvas = document.getElementById('chart') as HTMLCanvasElement;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const data = {
+      labels: record.statusHistory.map((_, i) => `${i + 1}`),
+      datasets: [
+        {
+          label: 'Status',
+          data: record.statusHistory.map((s) => (s === 'fail' ? 1 : 0)),
+          backgroundColor: record.statusHistory.map((s) => (s === 'fail' ? 'red' : 'green')),
+        },
+      ],
+    };
+    new Chart(ctx, {
+      type: 'bar',
+      data,
+      options: {
+        plugins: { legend: { display: false } },
+        scales: { y: { beginAtZero: true, max: 1 } },
+      },
+    });
+  }, [record]);
+
+  if (!record) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <Link to="/" className="text-blue-600 underline">Back</Link>
+      <h2 className="text-xl font-bold mb-4">{record.name}</h2>
+      <canvas id="chart" height="100"></canvas>
+    </div>
+  );
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"] ,
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: ['..']
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- implement `Runner` class to execute arbitrary test commands multiple times
- add CLI in `main.ts` to run the runner and output a summary
- document usage in README
- add a simple React + Vite dashboard under `ui/` for viewing `results.json`
- update package.json with minimist and type deps

## Testing
- `npm test`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_688abd2c651883319e4b1b521a6d596c